### PR TITLE
- Added support for delete image from input folder

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -115,6 +115,26 @@ async def delete_output_images(request: Request):
     except Exception as e:
         return error_resp(500, str(e))
 
+@routes.delete("/comfyapi/v1/input-images/{filename}")
+async def delete_input_images(request: Request):
+    try:
+        filename = request.match_info.get("filename")
+        if filename is None:
+            return error_resp(400, "filename is required")
+        
+        if filename[0] == '/' or '..' in filename:
+            return error_resp(400, "invalid filename")
+        
+        is_temp = request.rel_url.query.get("temp", "false") == "true"
+        annotated_file = f"{filename} [{'temp' if is_temp else 'input'}]"
+        if not folder_paths.exists_annotated_filepath(annotated_file):
+            return error_resp(404, f"file {filename} not found")
+        
+        filepath = folder_paths.get_annotated_filepath(annotated_file)
+        os.remove(filepath)
+        return success_resp()
+    except Exception as e:
+        return error_resp(500, str(e))
 
 @routes.post("/comfyapi/v1/pnginfo")
 async def get_png_info(request: Request):


### PR DESCRIPTION
When using API for process image or some reason ComfyUI start working too slow when input folder has 1k+ images and simple upscale procedure grow from 0.1s to 10s for example (i think it's cause workflow has input image with filename didn't exist in comfy (using as placeholder))
So, i added support to able to remove input file after process (same like for output)